### PR TITLE
Darkmode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@babel/preset-react": "^7.13.13",
         "@babel/preset-typescript": "^7.13.0",
         "@testing-library/react": "^11.2.7",
+        "@testing-library/user-event": "^13.1.9",
         "@types/jest": "^26.0.23",
         "babel-jest": "^27.0.2",
         "jest": "^27.0.4",
@@ -2580,6 +2581,22 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "13.1.9",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.1.9.tgz",
+      "integrity": "sha512-NZr0zL2TMOs2qk+dNlqrAdbaRW5dAmYwd1yuQ4r7HpkVEOj0MWuUjDWwKhcLd/atdBy8ZSMHSKp+kXSQe47ezg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -14167,6 +14184,15 @@
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^7.28.1"
+      }
+    },
+    "@testing-library/user-event": {
+      "version": "13.1.9",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.1.9.tgz",
+      "integrity": "sha512-NZr0zL2TMOs2qk+dNlqrAdbaRW5dAmYwd1yuQ4r7HpkVEOj0MWuUjDWwKhcLd/atdBy8ZSMHSKp+kXSQe47ezg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@babel/preset-react": "^7.13.13",
     "@babel/preset-typescript": "^7.13.0",
     "@testing-library/react": "^11.2.7",
+    "@testing-library/user-event": "^13.1.9",
     "@types/jest": "^26.0.23",
     "babel-jest": "^27.0.2",
     "jest": "^27.0.4",

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <noscript> You need to enable JavaScript to run this app. </noscript>
-    <div id="root"></div>
+    <main id="root"></div>
     <script src="/js/app.js"></script>
   </body>
 </html>

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,19 +1,22 @@
-import * as React from "react";
+import React from "react";
 import { BrowserRouter as Router, Switch, Route, Link } from "react-router-dom";
+import { DarkmodeProvider } from "./contexts/DarkmodeContext";
 import Home from "./pages/Home";
+
+interface AppProps {}
 
 const App = (props: AppProps) => {
   return (
-    <Router>
-      <Switch>
-        <Route path="/">
-          <Home />
-        </Route>
-      </Switch>
-    </Router>
+    <DarkmodeProvider>
+      <Router>
+        <Switch>
+          <Route path="/">
+            <Home />
+          </Route>
+        </Switch>
+      </Router>
+    </DarkmodeProvider>
   );
 };
-
-interface AppProps {}
 
 export default App;

--- a/src/client/components/DarkmodeToggle.tsx
+++ b/src/client/components/DarkmodeToggle.tsx
@@ -3,7 +3,7 @@ import { useDarkModeContext } from "../contexts/DarkmodeContext";
 
 type DarkmodeToggleProps = {};
 
-const DarkModeToggle: FunctionComponent<DarkmodeToggleProps> =
+const DarkmodeToggle: FunctionComponent<DarkmodeToggleProps> =
   ({}: DarkmodeToggleProps) => {
     const { darkmode, toggleDarkmode } = useDarkModeContext();
 
@@ -24,4 +24,4 @@ const DarkModeToggle: FunctionComponent<DarkmodeToggleProps> =
     );
   };
 
-export default DarkModeToggle;
+export default DarkmodeToggle;

--- a/src/client/components/DarkmodeToggle.tsx
+++ b/src/client/components/DarkmodeToggle.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, FunctionComponent } from "react";
+import { useDarkModeContext } from "../contexts/DarkmodeContext";
+
+type DarkmodeToggleProps = {};
+
+const DarkModeToggle: FunctionComponent<DarkmodeToggleProps> =
+  ({}: DarkmodeToggleProps) => {
+    const { darkmode, toggleDarkmode } = useDarkModeContext();
+
+    useEffect(() => {
+      document.body.className = darkmode ? "dark" : "";
+      return () => {
+        document.body.className = darkmode ? "" : "dark";
+      };
+    });
+
+    return (
+      <div className="toggle">
+        <label className="switch">
+          <input type="checkbox" onClick={toggleDarkmode} />
+          <div className="slider round">{darkmode ? "LIGHT?" : "DARK?"}</div>
+        </label>
+      </div>
+    );
+  };
+
+export default DarkModeToggle;

--- a/src/client/components/__tests__/DarkmodeToggle.test.tsx
+++ b/src/client/components/__tests__/DarkmodeToggle.test.tsx
@@ -1,34 +1,43 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import DarkModeToggle from "../DarkmodeToggle";
 import { DarkmodeProvider } from "../../contexts/DarkmodeContext";
 
 describe("<DarkmodeToggle />", () => {
-  beforeEach(() => {
-    render(
-      <DarkmodeProvider>
-        <DarkModeToggle />
-      </DarkmodeProvider>
-    );
+  afterEach(cleanup);
+
+  it("renders correct structure", () => {
+    const { container } = render(<DarkModeToggle />);
+    expect(container).toMatchSnapshot();
   });
 
-  describe("when component is initialized", () => {
-    it("then sets the light class by default", () => {
-      expect(screen.getByText(/Dark/i)).toBeTruthy();
-      expect(document.body.className).toEqual("");
-    });
-  });
-
-  describe("when the toggle theme input is clicked", () => {
+  describe("actions", () => {
     beforeEach(() => {
-      userEvent.click(screen.getByText(/Dark/i));
+      render(
+        <DarkmodeProvider>
+          <DarkModeToggle />
+        </DarkmodeProvider>
+      );
     });
 
-    it("then sets the dark class", () => {
-      expect(screen.getByText(/Light/i)).toBeTruthy();
-      expect(document.body.className).toEqual("dark");
+    describe("when component is initialized", () => {
+      it("then sets the light class by default", () => {
+        expect(screen.getByText(/Dark/i)).toBeTruthy();
+        expect(document.body.className).toEqual("");
+      });
+    });
+
+    describe("when the toggle theme input is clicked", () => {
+      beforeEach(() => {
+        userEvent.click(screen.getByText(/Dark/i));
+      });
+
+      it("then sets the dark class", () => {
+        expect(screen.getByText(/Light/i)).toBeTruthy();
+        expect(document.body.className).toEqual("dark");
+      });
     });
   });
 });

--- a/src/client/components/__tests__/DarkmodeToggle.test.tsx
+++ b/src/client/components/__tests__/DarkmodeToggle.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import DarkModeToggle from "../DarkmodeToggle";
+import { DarkmodeProvider } from "../../contexts/DarkmodeContext";
+
+describe("<DarkmodeToggle />", () => {
+  beforeEach(() => {
+    render(
+      <DarkmodeProvider>
+        <DarkModeToggle />
+      </DarkmodeProvider>
+    );
+  });
+
+  describe("when component is initialized", () => {
+    it("then sets the light class by default", () => {
+      expect(screen.getByText(/Dark/i)).toBeTruthy();
+      expect(document.body.className).toEqual("");
+    });
+  });
+
+  describe("when the toggle theme input is clicked", () => {
+    beforeEach(() => {
+      userEvent.click(screen.getByText(/Dark/i));
+    });
+
+    it("then sets the dark class", () => {
+      expect(screen.getByText(/Light/i)).toBeTruthy();
+      expect(document.body.className).toEqual("dark");
+    });
+  });
+});

--- a/src/client/components/__tests__/ExternalLink.test.tsx
+++ b/src/client/components/__tests__/ExternalLink.test.tsx
@@ -1,24 +1,26 @@
-import * as React from "react";
+import React from "react";
 import { cleanup, render } from "@testing-library/react";
 
 import ExternalLink from "../ExternalLink";
 
-afterEach(cleanup);
+describe("<ExternalLink />", () => {
+  afterEach(cleanup);
 
-test("renders correct structure with text children", () => {
-  const { container } = render(
-    <ExternalLink link="#" title="title-prop">
-      Link text
-    </ExternalLink>
-  );
-  expect(container).toMatchSnapshot();
-});
+  it("renders correct structure with text children", () => {
+    const { container } = render(
+      <ExternalLink link="#" title="title-prop">
+        Link text
+      </ExternalLink>
+    );
+    expect(container).toMatchSnapshot();
+  });
 
-test("renders correct structure with HTML children", () => {
-  const { container } = render(
-    <ExternalLink link="#" title="title-prop">
-      <div>inner div</div>
-    </ExternalLink>
-  );
-  expect(container).toMatchSnapshot();
+  it("renders correct structure with HTML children", () => {
+    const { container } = render(
+      <ExternalLink link="#" title="title-prop">
+        <div>inner div</div>
+      </ExternalLink>
+    );
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/src/client/components/__tests__/__snapshots__/DarkmodeToggle.test.tsx.snap
+++ b/src/client/components/__tests__/__snapshots__/DarkmodeToggle.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<DarkmodeToggle /> renders correct structure 1`] = `
+<div>
+  <div
+    class="toggle"
+  >
+    <label
+      class="switch"
+    >
+      <input
+        type="checkbox"
+      />
+      <div
+        class="slider round"
+      >
+        DARK?
+      </div>
+    </label>
+  </div>
+</div>
+`;

--- a/src/client/components/__tests__/__snapshots__/ExternalLink.test.tsx.snap
+++ b/src/client/components/__tests__/__snapshots__/ExternalLink.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correct structure with HTML children 1`] = `
+exports[`<ExternalLink /> renders correct structure with HTML children 1`] = `
 <div>
   <a
     href="#"
@@ -15,7 +15,7 @@ exports[`renders correct structure with HTML children 1`] = `
 </div>
 `;
 
-exports[`renders correct structure with text children 1`] = `
+exports[`<ExternalLink /> renders correct structure with text children 1`] = `
 <div>
   <a
     href="#"

--- a/src/client/contexts/DarkmodeContext.tsx
+++ b/src/client/contexts/DarkmodeContext.tsx
@@ -1,0 +1,34 @@
+import React, {
+  useContext,
+  useState,
+  FunctionComponent,
+  ReactNode,
+} from "react";
+
+type DarkmodeProviderProps = {
+  children: ReactNode;
+};
+type DarkmodeContextTypes = { darkmode: boolean; toggleDarkmode: () => void };
+
+const DarkmodeContext = React.createContext({
+  darkmode: false,
+  toggleDarkmode: () => {},
+});
+
+const useDarkModeContext: () => DarkmodeContextTypes = () =>
+  useContext(DarkmodeContext);
+
+const DarkmodeProvider: FunctionComponent<DarkmodeProviderProps> = ({
+  children,
+}: DarkmodeProviderProps) => {
+  const [darkmode, setDarkmode] = useState(false);
+  const toggleDarkmode = () => setDarkmode(!darkmode);
+
+  return (
+    <DarkmodeContext.Provider value={{ darkmode, toggleDarkmode }}>
+      {children}
+    </DarkmodeContext.Provider>
+  );
+};
+
+export { DarkmodeProvider, useDarkModeContext };

--- a/src/client/pages/Home.tsx
+++ b/src/client/pages/Home.tsx
@@ -9,7 +9,7 @@ import {
 } from "@fortawesome/free-brands-svg-icons";
 
 import ExternalLink from "../components/ExternalLink";
-import DarkModeToggle from "../components/DarkModeToggle";
+import DarkmodeToggle from "../components/DarkmodeToggle";
 
 type HomeProps = {};
 
@@ -22,7 +22,7 @@ const Home = ({}: HomeProps) => {
           className="avatar"
           src="img/jim.jpg"
         />
-        <DarkModeToggle />
+        <DarkmodeToggle />
       </div>
       <div className="wrapper">
         <h1 className="title">Jim Segal</h1>

--- a/src/client/pages/Home.tsx
+++ b/src/client/pages/Home.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
 import {
@@ -9,25 +9,20 @@ import {
 } from "@fortawesome/free-brands-svg-icons";
 
 import ExternalLink from "../components/ExternalLink";
+import DarkModeToggle from "../components/DarkModeToggle";
 
 type HomeProps = {};
 
 const Home = ({}: HomeProps) => {
   return (
-    <main className="home container">
+    <section className="home container">
       <div>
         <img
           alt="profile picture of me, Jim"
           className="avatar"
           src="img/jim.jpg"
         />
-        {/* TODO: make component
-         <div className="toggle">
-          <label className="switch">
-            <input type="checkbox" id="toggle-chk" />
-            <div className="slider round"></div>
-          </label>
-        </div> */}
+        <DarkModeToggle />
       </div>
       <div className="wrapper">
         <h1 className="title">Jim Segal</h1>
@@ -111,7 +106,7 @@ const Home = ({}: HomeProps) => {
           </ul>
         </div>
       </div>
-    </main>
+    </section>
   );
 };
 

--- a/src/client/pages/__tests__/Home.test.tsx
+++ b/src/client/pages/__tests__/Home.test.tsx
@@ -1,19 +1,21 @@
-import * as React from "react";
+import React from "react";
 import { cleanup, render } from "@testing-library/react";
 
 import Home from "../Home";
 
-beforeAll(() => {
-  // fix bug with font-awesome icon title
-  // https://github.com/FortAwesome/react-fontawesome/issues/194
-  const mockMath = Object.create(global.Math);
-  mockMath.random = () => 0;
-  global.Math = mockMath;
-});
+describe("<Home />", () => {
+  beforeAll(() => {
+    // fix bug with font-awesome icon title
+    // https://github.com/FortAwesome/react-fontawesome/issues/194
+    const mockMath = Object.create(global.Math);
+    mockMath.random = () => 0;
+    global.Math = mockMath;
+  });
 
-afterEach(cleanup);
+  afterEach(cleanup);
 
-test("renders correct structure", () => {
-  const { container } = render(<Home />);
-  expect(container).toMatchSnapshot();
+  it("renders correct structure", () => {
+    const { container } = render(<Home />);
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/src/client/pages/__tests__/__snapshots__/Home.test.tsx.snap
+++ b/src/client/pages/__tests__/__snapshots__/Home.test.tsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correct structure 1`] = `
+exports[`<Home /> renders correct structure 1`] = `
 <div>
-  <main
+  <section
     class="home container"
   >
     <div>
@@ -11,6 +11,22 @@ exports[`renders correct structure 1`] = `
         class="avatar"
         src="img/jim.jpg"
       />
+      <div
+        class="toggle"
+      >
+        <label
+          class="switch"
+        >
+          <input
+            type="checkbox"
+          />
+          <div
+            class="slider round"
+          >
+            DARK?
+          </div>
+        </label>
+      </div>
     </div>
     <div
       class="wrapper"
@@ -229,6 +245,6 @@ exports[`renders correct structure 1`] = `
         </ul>
       </div>
     </div>
-  </main>
+  </section>
 </div>
 `;

--- a/src/client/scss/app.scss
+++ b/src/client/scss/app.scss
@@ -129,3 +129,5 @@ a {
     }
   }
 }
+
+@import "darkmode.scss";

--- a/src/client/scss/darkmode.scss
+++ b/src/client/scss/darkmode.scss
@@ -8,6 +8,10 @@
 .dark {
   background: $grey;
   color: $light-grey;
+
+  a {
+    color: $light-grey;
+  }
 }
 
 .switch {
@@ -34,6 +38,7 @@
   border-radius: 34px;
   border: 2px solid $grey;
   padding-top: 5px;
+  text-align: center;
 }
 
 .slider:before {

--- a/src/client/scss/darkmode.scss
+++ b/src/client/scss/darkmode.scss
@@ -18,7 +18,7 @@
   position: relative;
   display: inline-block;
   width: 121px;
-  height: 36px;
+  height: 38px;
 }
 
 .switch input {
@@ -37,7 +37,7 @@
   transition: 0.4s;
   border-radius: 34px;
   border: 2px solid $grey;
-  padding-top: 5px;
+  padding-top: 7px;
   text-align: center;
 }
 

--- a/src/client/scss/darkmode.scss
+++ b/src/client/scss/darkmode.scss
@@ -1,0 +1,71 @@
+.toggle {
+  display: flex;
+  justify-content: center;
+  align-self: center;
+  margin-top: 5px;
+}
+
+.dark {
+  background: $grey;
+  color: $light-grey;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 121px;
+  height: 36px;
+}
+
+.switch input {
+  display: none;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: $light-grey;
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
+  border-radius: 34px;
+  border: 2px solid $grey;
+  padding-top: 5px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 26px;
+  width: 26px;
+  left: 4px;
+  bottom: 4px;
+  background-color: $grey;
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
+  border-radius: 50%;
+}
+
+input:checked + .slider {
+  color: $grey;
+  background-color: $light-grey;
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(84px);
+  -ms-transform: translateX(84px);
+  transform: translateX(84px);
+}
+
+// .slider:after {
+//   color: $grey;
+//   display: block;
+//   position: absolute;
+//   transform: translate(-50%, -50%);
+//   top: 50%;
+//   left: 50%;
+//   font-size: 14px;
+// }

--- a/src/client/scss/darkmode.scss
+++ b/src/client/scss/darkmode.scss
@@ -11,6 +11,9 @@
 
   a {
     color: $light-grey;
+    &:hover {
+      color: $focus-color;
+    }
   }
 }
 

--- a/src/client/scss/darkmode.scss
+++ b/src/client/scss/darkmode.scss
@@ -59,13 +59,3 @@ input:checked + .slider:before {
   -ms-transform: translateX(84px);
   transform: translateX(84px);
 }
-
-// .slider:after {
-//   color: $grey;
-//   display: block;
-//   position: absolute;
-//   transform: translate(-50%, -50%);
-//   top: 50%;
-//   left: 50%;
-//   font-size: 14px;
-// }


### PR DESCRIPTION
fixes #28 

Adds 
- dark mode component and tests
- dark mode context and provider

Alters
- semantic html in index.html, home component
- import * as React from "react" -> import React from "react"
- App to be wrapped with DarkmodeProvider
- Home to import Darkmode component

